### PR TITLE
Fix for edge case rounding errors breaking bad triangle selection

### DIFF
--- a/addons/gdDelaunay/Delaunay.gd
+++ b/addons/gdDelaunay/Delaunay.gd
@@ -61,6 +61,8 @@ class Triangle:
 		radius_sqr = a.distance_squared_to(center)
 	
 	func is_point_inside_circumcircle(point: Vector2) -> bool:
+		if point == a or point == b or point == c:
+			return false
 		return center.distance_squared_to(point) < radius_sqr
 	
 	func is_corner(point: Vector2) -> bool:


### PR DESCRIPTION
After some testing, discovered that in some edge cases "Triangle.is_point_inside_circumcircle(point)" will flag the corners as being inside the circumcircle (which of course is counter to the logic of the algorithm). By simply checking and ignoring its own corners, all of my personal issues relating to broken polygons similar to #1 have been resolved.